### PR TITLE
Rename Indicadores group to Parametros

### DIFF
--- a/modelo_padrão_de_utilizacao_de_indicadores.lua
+++ b/modelo_padrão_de_utilizacao_de_indicadores.lua
@@ -1,5 +1,5 @@
 input_group {
-    "Indicadores",
+    "Parametros",
     MIN_VOTES   = input(6,    "Min votes",          input.integer,   1,  10, 1),
     MIN_CANDLES = input(15,   "Min candles",        input.integer,   1,  10, 1),
     BB_PER      = input(26,   "BB period",          input.integer,   5, 100, 1),


### PR DESCRIPTION
## Summary
- rename input group "Indicadores" to "Parametros"

## Testing
- `lua -v`
- `luac -p modelo_padrão_de_utilizacao_de_indicadores.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a6bc72a040832599f9465d1b255fbc